### PR TITLE
Fixed #38: Molecule tests now run again by disabling SELinux check when running molecule

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -3,6 +3,8 @@ Changelog of Pythia:
 Version 2.3.5
   - New Feature #34: using the shell command with sqlplus has been replaced by the oracle_sql
     module
+  - Fixed #38: Molecule tests now run again by disabling SELinux check when running molecule
+    and updating the meta/main.yml with the needed Ansible Galaxy info.
 
 Version 2.3.0
   - New Feature #25: You can now specify a list of instance parameters which will get set

--- a/roles/pythia/meta/main.yml
+++ b/roles/pythia/meta/main.yml
@@ -1,6 +1,7 @@
 galaxy_info:
-  author: Philip Haberkern - thedatabaseme
+  author: thedatabaseme
   description: Pythia is a Role for ansible that helps you to automate Oracle Database Installation, Configuration and Patching tasks.
+  role_name: pythia
   company:
 
   # If the issue tracker for your role is not on github, uncomment the

--- a/roles/pythia/molecule/default/converge.yml
+++ b/roles/pythia/molecule/default/converge.yml
@@ -9,6 +9,7 @@
     runinstaller_parameters: " -ignoreInternalDriverError"
     install_patch: "33239276"
     emexpress: NONE
+    molecule_run: true
 
   roles:
     - pythia

--- a/roles/pythia/molecule/install_db/converge.yml
+++ b/roles/pythia/molecule/install_db/converge.yml
@@ -7,6 +7,7 @@
     oracle_sid: ORA21
     sga_max_size: 2
     emexpress: NONE
+    molecule_run: true
 
   roles:
     - pythia

--- a/roles/pythia/molecule/install_patch/converge.yml
+++ b/roles/pythia/molecule/install_patch/converge.yml
@@ -5,6 +5,7 @@
   vars:
     oracle_version: 21EE
     install_patch: 33239276
+    molecule_run: true
 
   roles:
     - pythia

--- a/roles/pythia/molecule/install_rdbms/converge.yml
+++ b/roles/pythia/molecule/install_rdbms/converge.yml
@@ -7,6 +7,7 @@
     oracle_sid: ORA21
     sga_max_size: 2
     runinstaller_parameters: " -ignoreInternalDriverError"
+    molecule_run: true
 
   roles:
     - pythia

--- a/roles/pythia/molecule/install_rdbms_db_patch/converge.yml
+++ b/roles/pythia/molecule/install_rdbms_db_patch/converge.yml
@@ -9,6 +9,7 @@
     runinstaller_parameters: " -ignoreInternalDriverError"
     install_patch: "33239276"
     emexpress: NONE
+    molecule_run: true
 
   roles:
     - pythia

--- a/roles/pythia/tasks/prerequisites.yml
+++ b/roles/pythia/tasks/prerequisites.yml
@@ -459,6 +459,7 @@
   changed_when: false
   register: check_selinux_configuration
   become: true
+  when: (not molecule_run | bool | default(false))
   tags:
     - autostart
     - db
@@ -487,7 +488,7 @@
     state: "{{ selinux_desired_state }}"
   register: selinux_configuration_change
   become: true
-  when: '("SELinux state changed" in check_selinux_configuration.msg)'
+  when: '((not molecule_run | bool | default(false)) and ("SELinux state changed" in check_selinux_configuration.msg))'
   tags:
     - autostart
     - db


### PR DESCRIPTION
Fixed #38: Molecule tests now run again by disabling SELinux check when running molecule
    and updating the meta/main.yml with the needed Ansible Galaxy info.