### PR TITLE
Fixed #42: Prereq packages added

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -1,5 +1,9 @@
 Changelog of Pythia:
 
+Version 2.3.7
+  - Fixed #42: insserv-compat and compat-libpthread-nonshared have been added to SLES15
+    prereq packages
+
 Version 2.3.6
   - Fixed #3: Pythia now checks if there are running instances before adjusting the sysctl.conf
 

--- a/roles/pythia/tasks/main.yml
+++ b/roles/pythia/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 # ####################################################################
 # Main Task File for Pythia
-# Version 2.3.6
+# Version 2.3.7
 # Author: thedatabaseme / Philip Haberkern
 # For more Details view README.md
 # ####################################################################

--- a/roles/pythia/vars/main.yml
+++ b/roles/pythia/vars/main.yml
@@ -95,6 +95,8 @@ sles15_packages:
   - psmisc
   - acl
   - unzip
+  - compat-libpthread-nonshared
+  - insserv-compat
 
 sles12_packages:
   - bc


### PR DESCRIPTION
Fixed #42  insserv-compat and compat-libpthread-nonshared have been added to SLES15 prereq packages